### PR TITLE
upgraded to 7.40.0.Final with wildfly19

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@
 #########################################################################
 
 ####### BASE ############
-FROM jboss/wildfly:18.0.1.Final
+FROM jboss/wildfly:19.1.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
@@ -11,8 +11,8 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
-ENV KIE_VERSION 7.38.0.Final
-ENV KIE_CLASSIFIER wildfly18
+ENV KIE_VERSION 7.40.0.Final
+ENV KIE_CLASSIFIER wildfly19
 ENV KIE_CONTEXT_PATH business-central
 ENV JAVA_OPTS -Xms256m -Xmx2048m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8
 ENV KIE_SERVER_PROFILE standalone

--- a/base/README.md
+++ b/base/README.md
@@ -21,8 +21,8 @@ Introduction
 
 The image contains:  
              
-* JBoss Wildfly 18.0.1.Final
-* JBoss Business-Central Workbench 7.38.0.Final
+* JBoss Wildfly 19.1.0.Final
+* JBoss Business-Central Workbench 7.40.0.Final
 
 This image provides the JBoss Business-Central Workbench. It's intended to be extended so you can add your custom configurations.
 
@@ -217,7 +217,7 @@ Notes
 -----
 
 * The context path for JBoss Business-Central Workbench web application is `business-central`
-* JBoss Business-Central Workbench version is `7.38.0.Final`
+* JBoss Business-Central Workbench version is `7.40.0.Final`
 * No users or roles are configured by default               
 * No support for clustering                
 * Use of embedded H2 database server by default               
@@ -231,6 +231,6 @@ versions > 7.18.0.Final
 Release notes
 --------------
 
-**7.38.0.Final**
+**7.40.0.Final**
 
-* See release notes for [JBoss Business-Central](http://docs.jboss.org/jbpm/release/7.38.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [JBoss Business-Central](http://docs.jboss.org/jbpm/release/7.40.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/kie-server/base/Dockerfile
+++ b/kie-server/base/Dockerfile
@@ -3,7 +3,7 @@
 #########################################################
 
 ####### BASE ############
-FROM jboss/wildfly:18.0.1.Final
+FROM jboss/wildfly:19.1.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
-ENV KIE_VERSION 7.38.0.Final
+ENV KIE_VERSION 7.40.0.Final
 ENV KIE_CLASSIFIER ee7
 ENV KIE_CONTEXT_PATH kie-server
 ENV JAVA_OPTS -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8

--- a/kie-server/base/README.md
+++ b/kie-server/base/README.md
@@ -3,7 +3,7 @@ Drools KIE Server Docker image
 
 Drools KIE Server [Docker](http://docker.io/) image.
 
-More information of KIE Server available at [JBoss documentation](https://docs.jboss.org/drools/release/7.38.0.Final/drools-docs/html_single/#_ch.kie.server).
+More information of KIE Server available at [JBoss documentation](https://docs.jboss.org/drools/release/7.40.0.Final/drools-docs/html_single/#_ch.kie.server).
 
 Table of contents
 ------------------
@@ -22,8 +22,8 @@ Introduction
 
 The image contains:    
            
-* JBoss Wildfly 18.0.1.Final
-* JBoss Drools KIE Server 7.38.0.Final
+* JBoss Wildfly 19.1.0.Final
+* JBoss Drools KIE Server 7.40.0.Final
 
 This image provides the Drools KIE Server. It's intended to be extended so you can add your custom configurations.                 
 
@@ -33,7 +33,7 @@ Usage
 -----
 
 The JBoss KIE Execution server is intended to be used as a standalone runtime execution environment managed by a KIE Drools Workbench or a jBPM Workbench application that acts as a controller.              
-This image does not provides any default configuration, so please to use the execution server it's recommended to read the documentation at [Installing the KIE Server](https://docs.jboss.org/drools/release/7.38.0.Final/drools-docs/html_single/#_installing_the_kie_server). You can check an example of this configuration at the [KIE Server Showcase](https://registry.hub.docker.com/u/jboss/kie-server-showcase/) Docker image too.
+This image does not provides any default configuration, so please to use the execution server it's recommended to read the documentation at [Installing the KIE Server](https://docs.jboss.org/drools/release/7.40.0.Final/drools-docs/html_single/#_installing_the_kie_server). You can check an example of this configuration at the [KIE Server Showcase](https://registry.hub.docker.com/u/jboss/kie-server-showcase/) Docker image too.
 
 To run a container:
     
@@ -154,7 +154,7 @@ Notes
 -----
 
 * The context path for Drools KIE Server application services is `kie-server`
-* Drools KIE Server version is `7.38.0.Final`
+* Drools KIE Server version is `7.40.0.Final`
 * No users or roles are configured by default               
 * No support for clustering                
 * This image is not intended to be run on cloud environments such as RedHat OpenShift or Amazon EC2, as it does not meet all the requirements.                      
@@ -163,7 +163,7 @@ Notes
 Release notes
 --------------
 
-**7.38.0.Final**
+**7.40.0.Final**
 
-* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.38.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
+* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.40.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
 

--- a/kie-server/showcase/Dockerfile
+++ b/kie-server/showcase/Dockerfile
@@ -3,7 +3,7 @@
 #########################################################
 
 ####### BASE ############
-FROM jboss/kie-server:7.38.0.Final
+FROM jboss/kie-server:7.40.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"

--- a/kie-server/showcase/README.md
+++ b/kie-server/showcase/README.md
@@ -3,7 +3,7 @@ Drools KIE Server showcase Docker image
 
 Drools KIE Server showcase [Docker](http://docker.io/) image.
 
-More information of KIE Server available at [JBoss documentation](http://docs.jboss.org/drools/release/7.38.0.Final/drools-docs/html_single/#_ch.kie.server).
+More information of KIE Server available at [JBoss documentation](http://docs.jboss.org/drools/release/7.40.0.Final/drools-docs/html_single/#_ch.kie.server).
 
 Table of contents
 ------------------
@@ -22,8 +22,8 @@ Introduction
 
 The image contains: 
               
-* JBoss Wildfly 18.0.1.Final
-* JBoss Drools KIE Server 7.38.0.Final
+* JBoss Wildfly 19.1.0.Final
+* JBoss Drools KIE Server 7.40.0.Final
 
 This is a **ready to run Docker image for Drools KIE Server**. Just run it and try the Drools runtime execution server!                   
 
@@ -46,7 +46,7 @@ As in the above example, the use of the link alias `kie-wb` produces:
 
 So at the point the execution server container is up and running, this server instance will be automatically detected and available in your Drools/jBPM Workbench application, so you can deploy and run your application rules, etc into it.                 
 
-For more information, please read the documentation at [Installing the KIE Server](http://docs.jboss.org/drools/release/7.38.0.Final/drools-docs/html_single/#_installing_the_kie_server).
+For more information, please read the documentation at [Installing the KIE Server](http://docs.jboss.org/drools/release/7.40.0.Final/drools-docs/html_single/#_installing_the_kie_server).
 
 Once container and web applications started, the application is available at:              
 
@@ -94,7 +94,7 @@ Notes
 -----
 
 * The context path for Drools KIE Server application services is `kie-server`
-* Drools KIE Server version is `7.38.0.Final`
+* Drools KIE Server version is `7.40.0.Final`
 * In order to perform container linking with a jBPM / Drools Workbench image, the link alias must be `kie-wb`       
 * No support for clustering                
 * This image is not intended to be run on cloud environments such as RedHat OpenShift or Amazon EC2, as it does not meet all the requirements.                      
@@ -103,6 +103,6 @@ Notes
 Release notes
 -------------
 
-**7.38.0.Final**
+**7.40.0.Final**
 
-* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.38.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
+* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.40.0.Final/drools-docs/html_single/index.html#_ch.kie.server)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@
 ###############################################################
 
 ####### BASE ############
-FROM jboss/wildfly:18.0.1.Final
+FROM jboss/wildfly:19.1.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
@@ -11,8 +11,8 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://download.jboss.org/jbpm/release
-ENV KIE_VERSION 7.38.0.Final
-ENV KIE_CLASSIFIER wildfly18
+ENV KIE_VERSION 7.40.0.Final
+ENV KIE_CLASSIFIER wildfly19
 ENV KIE_CONTEXT_PATH business-central
 ENV KIE_SERVER_ID sample-server
 ENV KIE_SERVER_LOCATION http://localhost:8080/kie-server/services/rest/server

--- a/server/README.md
+++ b/server/README.md
@@ -24,10 +24,10 @@ Introduction
 
 The image contains:
 
-* JBoss Wildfly 18.0.1.Final
-* jBPM Workbench 7.38.0.Final
-* KIE Server 7.38.0.Final
-* jBPM Case Management Showcase 7.38.0.Final
+* JBoss Wildfly 19.1.0.Final
+* jBPM Workbench 7.40.0.Final
+* KIE Server 7.40.0.Final
+* jBPM Case Management Showcase 7.40.0.Final
 
 This is a **ready to run Docker image for jBPM Workbench**. Just run it and try the jBPM Workbench!
 
@@ -179,11 +179,11 @@ Try:
 Notes
 -----
 
-* jBPM Workbench version is `7.38.0.Final`
+* jBPM Workbench version is `7.40.0.Final`
 * The context path for jBPM Workbench web application is `business-central`
-* KIE Server version is `7.38.0.Final`
+* KIE Server version is `7.40.0.Final`
 * The context path for KIE Server web application is `kie-server`
-* jBPM Case Management Showcase version is `7.38.0.Final`
+* jBPM Case Management Showcase version is `7.40.0.Final`
 * The context path for jBPM Case Management Showcase web application is `jbpm-casemgmt`
 * Examples and demos are always available, also when not connected to internet
 * No support for clustering
@@ -195,6 +195,6 @@ Notes
 Release notes
 --------------
 
-**7.38.0.Final**
+**7.40.0.Final**
 
-* See release notes for [jBPM](http://docs.jboss.org/jbpm/release/7.38.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [jBPM](http://docs.jboss.org/jbpm/release/7.40.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/showcase/Dockerfile
+++ b/showcase/Dockerfile
@@ -3,7 +3,7 @@
 #########################################################################
 
 ####### BASE ############
-FROM jboss/business-central-workbench:7.38.0.Final
+FROM jboss/business-central-workbench:7.40.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -22,8 +22,8 @@ Introduction
 
 The image contains:
 
-* JBoss Wildfly 18.0.1.Final
-* JBoss Business-Central Workbench 7.38.0.Final
+* JBoss Wildfly 19.1.0.Final
+* JBoss Business-Central Workbench 7.40.0.Final
 
 This image inherits from `jboss/business-central-workbench:latest` and provides some additional configurations:
 
@@ -184,7 +184,7 @@ Notes
 -----
 
 * The context path for JBoss Business-Central Workbench web application is `business-central`
-* JBoss Business-Central Workbench version is `7.38.0.Final`
+* JBoss Business-Central Workbench version is `7.40.0.Final`
 * Examples and demos are always available, also when not connected to internet
 * No support for clustering
 * Use of embedded H2 database server by default
@@ -198,6 +198,6 @@ versions > 7.18.0.Final
 Release notes
 --------------
 
-**7.38.0.Final**
+**7.40.0.Final**
 
-* See release notes for [JBoss Business-Central](http://docs.jboss.org/jbpm/release/7.38.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [JBoss Business-Central](http://docs.jboss.org/jbpm/release/7.40.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)


### PR DESCRIPTION
There is not a version 7.39.0.Final: this version was buggy and would have been ready maybe two days ago.
Now everything works again with 7.40.0.Final and the upgrade to wildfly19.