### PR TITLE
fix ee8 for wildfly

### DIFF
--- a/kie-server/base/Dockerfile
+++ b/kie-server/base/Dockerfile
@@ -12,7 +12,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
 ENV KIE_VERSION 7.52.0.Final
-ENV KIE_CLASSIFIER ee7
+ENV KIE_CLASSIFIER ee8
 ENV KIE_CONTEXT_PATH kie-server
 ENV JAVA_OPTS -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8
 


### PR DESCRIPTION
@mbiarnes shouldn't it point to ee8 classifier for wildfly? Currently, ee7 should be for WebLogic, WebSphere and webc for Tomcat/JWS.