### PR TITLE
First iteration of persisted solution.

### DIFF
--- a/docker-compose-examples/jbpm-full-postres-persistent.yml
+++ b/docker-compose-examples/jbpm-full-postres-persistent.yml
@@ -1,0 +1,30 @@
+# This file makes runtime files persistent to the jdata volume in docker.
+
+version: '2'
+
+volumes:
+  postgres_data:
+    driver: local
+  jdata:
+
+services:
+  postgres:
+    image: postgres
+    volumes:
+    - postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: jbpm
+      POSTGRES_USER: jbpm
+      POSTGRES_PASSWORD: jbpm
+  jbpm:
+    image: jboss/jbpm-server-full
+    environment:
+      JBPM_DB_DRIVER: postgres
+      JBPM_DB_HOST: postgres
+    ports:
+    - 8080:8080
+    - 8001:8001
+    depends_on:
+    - postgres
+    volumes:
+      - "jdata:/opt/jboss/wildfly/bin"


### PR DESCRIPTION
This docker-compose file follows the docker image instructions for persisting data to jbpm.

Interestingly, mapping to /opt/jboss/wildfly/bin/.niogit created a 404. Mapping to bin made persistence stick.

[Docker Hub](https://hub.docker.com/r/jboss/jbpm-server-full/)