### PR TITLE
upgraded to 7.63.0.Final

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
-ENV KIE_VERSION 7.62.0.Final
+ENV KIE_VERSION 7.63.0.Final
 ENV KIE_CLASSIFIER wildfly23
 ENV KIE_CONTEXT_PATH business-central
 ENV JAVA_OPTS -Xms256m -Xmx2048m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8

--- a/base/README.md
+++ b/base/README.md
@@ -24,7 +24,7 @@ Introduction
 The image contains:  
              
 * JBoss Wildfly 23.0.2.Final
-* KIE Business-Central Workbench 7.62.0.Final
+* KIE Business-Central Workbench 7.63.0.Final
 
 This image provides the KIE Business-Central Workbench. It's intended to be extended so you can add your custom configurations.
 
@@ -139,12 +139,12 @@ In order to extend this image, your Dockerfile must inherit from:
 
 These are the steps to create custom users and roles by using realm files in Widlfly:                  
 
-1.- copy the whole dir https://github.com/kiegroup/business-central/tree/7.62.0.Final/showcase/etc/kie-fs-realm-users to<br>
+1.- copy the whole dir https://github.com/kiegroup/business-central/tree/7.63.0.Final/showcase/etc/kie-fs-realm-users to<br>
 $JBOSS_HOME/standalone/configuration/
 
 kie-fs-realm-users should be owned by user jboss (chown jboss:jboss -R $JBOSS_HOME/standalone/configuration/kie-fs-realm-users)
 
-2.- copy the file https://github.com/mbiarnes/business-central/blob/7.62.0.Final/showcase/etc/jbpm-custom.cli to<br>
+2.- copy the file https://github.com/mbiarnes/business-central/blob/7.63.0.Final/showcase/etc/jbpm-custom.cli to<br>
 $JBOSS_HOME/bin/
 
 With this you have created the users
@@ -186,7 +186,7 @@ Notes
 -----
 
 * The context path for KIE Business-Central Workbench web application is `business-central`
-* KIE Business-Central Workbench version is `7.62.0.Final`
+* KIE Business-Central Workbench version is `7.63.0.Final`
 * No users or roles are configured by default               
 * No support for clustering                
 * Use of embedded H2 database server by default               
@@ -199,6 +199,6 @@ Notes
 Release notes
 --------------
 
-**7.62.0.Final**
+**7.63.0.Final**
 
-* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.62.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.63.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/base/build.sh
+++ b/base/build.sh
@@ -5,7 +5,7 @@
 # *************************************************************
 
 IMAGE_NAME="kiegroup/business-central-workbench"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 # Build the container image.

--- a/base/start.sh
+++ b/base/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="business-central"
 IMAGE_NAME="kiegroup/business-central-workbench"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 

--- a/docker-compose-examples/bc-kie-server.yml
+++ b/docker-compose-examples/bc-kie-server.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  showcase:
+    image: quay.io/kiegroup/business-central-workbench-showcase:latest
+    ports:
+      - "8083:8080"
+      - "8003:8001"
+    # networks:
+    #   - bcn
+    environment:
+      KIE_SERVER_LOCATION：http://kieserver:8090/kie-server/services/rest/server"
+
+  kieserver:
+    image: quay.io/kiegroup/kie-server-showcase:latest
+    ports:
+      - "8088:8080"
+    # networks:
+    #   - bcn
+    environment:
+      KIE_SERVER_LOCATION: http://kieserver:8080/kie-server/services/rest/server
+      KIE_SERVER_CONTROLLER: http://showcase:8080/business-central/rest/controller
+      KIE_MAVEN_REPO: http://showcase:8080/business-central/maven2

--- a/docker-compose-examples/jbpm-kie-server.yml
+++ b/docker-compose-examples/jbpm-kie-server.yml
@@ -2,12 +2,12 @@ version: '2'
 
 services:
   business-central:
-    image: jboss/business-central-workbench-showcase
+    image: localhost/jboss/business-central-workbench-showcase
     ports:
     - 8080:8080
     - 8001:8001
   kie-server:
-    image: jboss/kie-server-showcase
+    image: localhost/jboss/kie-server-showcase
     environment:
       KIE_SERVER_LOCATION: http://kie-server:8080/kie-server/services/rest/server
       KIE_SERVER_CONTROLLER: http://business-central:8080/business-central/rest/controller

--- a/kie-server/base/Dockerfile
+++ b/kie-server/base/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
-ENV KIE_VERSION 7.62.0.Final
+ENV KIE_VERSION 7.63.0.Final
 ENV KIE_CLASSIFIER ee8
 ENV KIE_CONTEXT_PATH kie-server
 ENV JAVA_OPTS -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8

--- a/kie-server/base/README.md
+++ b/kie-server/base/README.md
@@ -5,7 +5,7 @@ We changed the location for our docker images from Docker to [RedHat Quay](https
 
 From the versions > 7.61.0.Final on the images will only be available on Quay.
 
-More information of KIE Server available at [KIE documentation](https://docs.jboss.org/drools/release/7.62.0.Final/drools-docs/html_single/#_ch.kie.server).
+More information of KIE Server available at [KIE documentation](https://docs.jboss.org/drools/release/7.63.0.Final/drools-docs/html_single/#_ch.kie.server).
 
 Table of contents
 ------------------
@@ -25,7 +25,7 @@ Introduction
 The image contains:    
            
 * JBoss Wildfly 23.0.2.Final
-* KIE Server 7.62.0.Final
+* KIE Server 7.63.0.Final
 
 This image provides the Drools KIE Server. It's intended to be extended so you can add your custom configurations.                 
 
@@ -35,7 +35,7 @@ Usage
 -----
 
 The JBoss KIE Execution server is intended to be used as a standalone runtime execution environment managed by a KIE Drools Workbench or a jBPM Workbench application that acts as a controller.              
-This image does not provides any default configuration, so please to use the execution server it's recommended to read the documentation at [Installing the KIE Server](https://docs.jboss.org/drools/release/7.62.0.Final/drools-docs/html_single/#_installing_the_kie_server). You can check an example of this configuration at the [KIE Server Showcase](https://registry.hub.docker.com/u/jboss/kie-server-showcase/) Docker image too.
+This image does not provides any default configuration, so please to use the execution server it's recommended to read the documentation at [Installing the KIE Server](https://docs.jboss.org/drools/release/7.63.0.Final/drools-docs/html_single/#_installing_the_kie_server). You can check an example of this configuration at the [KIE Server Showcase](https://registry.hub.docker.com/u/jboss/kie-server-showcase/) Docker image too.
 
 To run a container:
     
@@ -156,7 +156,7 @@ Notes
 -----
 
 * The context path for KIE Server application services is `kie-server`
-* Drools KIE Server version is `7.62.0.Final`
+* Drools KIE Server version is `7.63.0.Final`
 * No users or roles are configured by default               
 * No support for clustering                
 * This image is not intended to be run on cloud environments such as RedHat OpenShift or Amazon EC2, as it does not meet all the requirements.                      
@@ -167,7 +167,7 @@ Notes
 Release notes
 --------------
 
-**7.62.0.Final**
+**7.63.0.Final**
 
-* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.62.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
+* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.63.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
 

--- a/kie-server/base/build.sh
+++ b/kie-server/base/build.sh
@@ -5,7 +5,7 @@
 # ********************************************
 
 IMAGE_NAME="kiegroup/kie-server"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 # Build the container image.

--- a/kie-server/base/start.sh
+++ b/kie-server/base/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="kie-server"
 IMAGE_NAME="kiegroup/kie-server"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 function usage

--- a/kie-server/showcase/Dockerfile
+++ b/kie-server/showcase/Dockerfile
@@ -3,7 +3,7 @@
 #########################################################
 
 ####### BASE ############
-FROM kiegroup/kie-server:7.62.0.Final
+FROM kiegroup/kie-server:7.63.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
@@ -13,8 +13,6 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ENV KIE_SERVER_LOCATION http://localhost:8080/kie-server/services/rest/server
 ENV KIE_SERVER_USER kieserver
 ENV KIE_SERVER_PWD kieserver1!
-# When using this image against jboss/jbpm-workbench-showcase use /jbpm-console/rest/controller
-# ENV KIE_SERVER_CONTROLLER http://localhost:8080/kie-wb/rest/controller
 ENV KIE_SERVER_CONTROLLER_USER admin
 ENV KIE_SERVER_CONTROLLER_PWD admin
 ENV KIE_MAVEN_REPO http://localhost:8080/kie-wb/maven2

--- a/kie-server/showcase/README.md
+++ b/kie-server/showcase/README.md
@@ -5,7 +5,7 @@ We changed the location for our docker images from Docker to [RedHat Quay](https
 
 From the versions > 7.61.0.Final on the images will only be available on Quay.
 
-More information of KIE Server available at [KIE documentation](http://docs.jboss.org/drools/release/7.62.0.Final/drools-docs/html_single/#_ch.kie.server).
+More information of KIE Server available at [KIE documentation](http://docs.jboss.org/drools/release/7.63.0.Final/drools-docs/html_single/#_ch.kie.server).
 
 Table of contents
 ------------------
@@ -25,38 +25,27 @@ Introduction
 The image contains: 
               
 * JBoss Wildfly 23.0.2.Final
-* KIE Server 7.62.0.Final
+* KIE Server 7.63.0.Final
 
-This is a **ready to run Docker image for Drools KIE Server**. Just run it and try the Drools runtime execution server!                   
+This is a **ready to run Docker image for Drools KIE Server**. Just run it and try the business-central runtime execution server!                   
 
 Usage
 -----
+Since `--link` is legacy we had to change the previous command by a simple docker-compose file.
 
-The JBoss KIE Execution server is intended to be used as a standalone runtime execution environment managed by a KIE Drools Workbench or a jBPM Workbench application that acts as a controller.             
+The JBoss KIE Execution server is intended to be used as a standalone runtime execution environment managed by a Business-Central Workbench application that acts as a controller.             
 
-Once having a KIE Drools Workbench or a jBPM Workbench application container running, you can run several execution server instances linked with your workbench by running:                                 
-    
-    # NOTE: Consider 'business-central-wb' as the name of your busines-central-showcase workbench running container.     
-    docker run -p 8180:8080 -d --name kie-server --link business-central-wb:kie-wb quay.io/kiegroup/kie-server-showcase:latest
-
-Note: Port `8080` is bind to port `8180` on the docker host considering that `business-central-wb` container is already using it.         
- 
-As in the above example, the use of the link alias `kie-wb` produces:               
-  
-* Use of your `business-central-wb` container as the controller for the execution server.                     
-* The repository in the Maven settings, for consuming your artifacts from the `business-central-wb` container, is automatically set.                    
-
-So at the point the execution server container is up and running, this server instance will be automatically detected and available in your Drools/jBPM Workbench application, so you can deploy and run your application rules, etc into it.                 
-
-For more information, please read the documentation at [Installing the KIE Server](http://docs.jboss.org/drools/release/7.62.0.Final/drools-docs/html_single/#_installing_the_kie_server).
+For running the container of Business-Central Workbench application as kie-server remote controller please run:                                 
+    podman-compose -f bc-kie-server.yml up
+* where bc-kie-server.yml is [bc-kie-server.yml](https://github.com/jboss-dockerfiles/business-central/blob/main/docker-compose-examples/bc-kie-server.yml)
 
 Once container and web applications started, the application is available at:              
 
-    http://localhost:8180/kie-server
+    http://localhost:8081/kie-server
 
 The **REST API service** is located at:               
 
-    http://localhost:8180/kie-server/services/rest/server/
+    http://localhost:8088/kie-server/services/rest/server/
 
 Users and roles
 ----------------
@@ -96,7 +85,7 @@ Notes
 -----
 
 * The context path for Drools KIE Server application services is `kie-server`
-* KIE Server version is `7.62.0.Final`
+* KIE Server version is `7.63.0.Final`
 * In order to perform container linking with a jBPM / Drools Workbench image, the link alias must be `kie-wb`       
 * No support for clustering                
 * This image is not intended to be run on cloud environments such as RedHat OpenShift or Amazon EC2, as it does not meet all the requirements.                      
@@ -107,6 +96,6 @@ Notes
 Release notes
 -------------
 
-**7.62.0.Final**
+**7.63.0.Final**
 
-* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.62.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
+* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.63.0.Final/drools-docs/html_single/index.html#_ch.kie.server)

--- a/kie-server/showcase/build.sh
+++ b/kie-server/showcase/build.sh
@@ -5,7 +5,7 @@
 # ************************************************
 
 IMAGE_NAME="kiegroup/kie-server-showcase"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 # Build the container image.

--- a/kie-server/showcase/start.sh
+++ b/kie-server/showcase/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="kie-server-showcase"
 IMAGE_NAME="kiegroup/kie-server-showcase"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 function usage

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://download.jboss.org/jbpm/release
-ENV KIE_VERSION 7.62.0.Final
+ENV KIE_VERSION 7.63.0.Final
 ENV KIE_CLASSIFIER wildfly23
 ENV KIE_CONTEXT_PATH business-central
 ENV KIE_SERVER_ID sample-server

--- a/server/README.md
+++ b/server/README.md
@@ -28,9 +28,9 @@ Introduction
 The image contains:
 
 * JBoss Wildfly 23.0.2.Final
-* jBPM Workbench 7.62.0.Final
-* KIE Server 7.62.0.Final
-* jBPM Case Management Showcase 7.62.0.Final
+* jBPM Workbench 7.63.0.Final
+* KIE Server 7.63.0.Final
+* jBPM Case Management Showcase 7.63.0.Final
 
 This is a **ready to run Docker image for jBPM Workbench**. Just run it and try the jBPM Workbench!
 
@@ -182,11 +182,11 @@ Try:
 Notes
 -----
 
-* jBPM Workbench version is `7.62.0.Final`
+* jBPM Workbench version is `7.63.0.Final`
 * The context path for jBPM Workbench web application is `business-central`
-* KIE Server version is `7.62.0.Final`
+* KIE Server version is `7.63.0.Final`
 * The context path for KIE Server web application is `kie-server`
-* jBPM Case Management Showcase version is `7.62.0.Final`
+* jBPM Case Management Showcase version is `7.63.0.Final`
 * The context path for jBPM Case Management Showcase web application is `jbpm-casemgmt`
 * Examples and demos are always available, also when not connected to internet
 * No support for clustering
@@ -200,6 +200,6 @@ Notes
 Release notes
 --------------
 
-**7.62.0.Final**
+**7.63.0.Final**
 
-* See release notes for [jBPM](http://docs.jboss.org/jbpm/release/7.62.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [jBPM](http://docs.jboss.org/jbpm/release/7.63.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/server/build.sh
+++ b/server/build.sh
@@ -5,7 +5,7 @@
 # ***************************************************
 
 IMAGE_NAME="kiegroup/jbpm-server-full"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 # Build the container image.

--- a/server/start.sh
+++ b/server/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="jbpm-server-full"
 IMAGE_NAME="kiegroup/jbpm-server-full"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 function usage

--- a/showcase/Dockerfile
+++ b/showcase/Dockerfile
@@ -3,7 +3,7 @@
 ############################################################################
 
 ####### BASE ############
-FROM kiegroup/business-central-workbench:7.62.0.Final
+FROM kiegroup/business-central-workbench:7.63.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -25,7 +25,7 @@ Introduction
 The image contains:
 
 * JBoss Wildfly 23.0.2.Final
-* KIE Business-Central Workbench 7.62.0.Final
+* KIE Business-Central Workbench 7.63.0.Final
 
 This image inherits from `quay.io/kiegroup/business-central-workbench:latest` and provides some additional configurations:
 
@@ -186,7 +186,7 @@ Notes
 -----
 
 * The context path for KIE Business-Central Workbench web application is `business-central`
-* KIE Business-Central Workbench version is `7.62.0.Final`
+* KIE Business-Central Workbench version is `7.63.0.Final`
 * Examples and demos are always available, also when not connected to internet
 * No support for clustering
 * Use of embedded H2 database server by default
@@ -199,6 +199,6 @@ Notes
 Release notes
 --------------
 
-**7.62.0.Final**
+**7.63.0.Final**
 
-* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.62.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.63.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/showcase/build.sh
+++ b/showcase/build.sh
@@ -5,7 +5,7 @@
 # *********************************************************************
 
 IMAGE_NAME="kiegroup/business-central-workbench-showcase"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 # Build the container image.

--- a/showcase/start.sh
+++ b/showcase/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="business-central-workbench-showcase"
 IMAGE_NAME="kiegroup/business-central-workbench-showcase"
-IMAGE_TAG="latest"
+IMAGE_TAG="7.63.0.Final"
 
 
 function usage


### PR DESCRIPTION
tagged with 7.63.0.Final

removed obsolete vars in Dockerfile

added new docker-compose example for running bc and kie-server as remote server

(cherry picked from commit 23b46e53207ef244f2aa1be8dccb2fd55e99610b)

changed images to pull from quay.io and the latest version

changed Readme because --link was replaced by a docker-compose file