### PR TITLE
V7.66.0.final

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
-ENV KIE_VERSION 7.65.0.Final
+ENV KIE_VERSION 7.66.0.Final
 ENV KIE_CLASSIFIER wildfly23
 ENV KIE_CONTEXT_PATH business-central
 ENV JAVA_OPTS -Xms256m -Xmx2048m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8

--- a/base/README.md
+++ b/base/README.md
@@ -24,7 +24,7 @@ Introduction
 The image contains:  
              
 * JBoss Wildfly 23.0.2.Final
-* KIE Business-Central Workbench 7.65.0.Final
+* KIE Business-Central Workbench 7.66.0.Final
 
 This image provides the KIE Business-Central Workbench. It's intended to be extended so you can add your custom configurations.
 
@@ -139,12 +139,12 @@ In order to extend this image, your Dockerfile must inherit from:
 
 These are the steps to create custom users and roles by using realm files in Widlfly:                  
 
-1.- copy the whole dir https://github.com/kiegroup/business-central/tree/7.65.0.Final/showcase/etc/kie-fs-realm-users to<br>
+1.- copy the whole dir https://github.com/kiegroup/business-central/tree/7.66.0.Final/showcase/etc/kie-fs-realm-users to<br>
 $JBOSS_HOME/standalone/configuration/
 
 kie-fs-realm-users should be owned by user jboss (chown jboss:jboss -R $JBOSS_HOME/standalone/configuration/kie-fs-realm-users)
 
-2.- copy the file https://github.com/mbiarnes/business-central/blob/7.65.0.Final/showcase/etc/jbpm-custom.cli to<br>
+2.- copy the file https://github.com/mbiarnes/business-central/blob/7.66.0.Final/showcase/etc/jbpm-custom.cli to<br>
 $JBOSS_HOME/bin/
 
 With this you have created the users
@@ -186,7 +186,7 @@ Notes
 -----
 
 * The context path for KIE Business-Central Workbench web application is `business-central`
-* KIE Business-Central Workbench version is `7.65.0.Final`
+* KIE Business-Central Workbench version is `7.66.0.Final`
 * No users or roles are configured by default               
 * No support for clustering                
 * Use of embedded H2 database server by default               
@@ -199,6 +199,6 @@ Notes
 Release notes
 --------------
 
-**7.65.0.Final**
+**7.66.0.Final**
 
-* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.65.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.66.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/base/build.sh
+++ b/base/build.sh
@@ -5,7 +5,7 @@
 # *************************************************************
 
 IMAGE_NAME="kiegroup/business-central-workbench"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 # Build the container image.

--- a/base/start.sh
+++ b/base/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="business-central"
 IMAGE_NAME="kiegroup/business-central-workbench"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 

--- a/docker-compose-examples/bc-kie-server.yml
+++ b/docker-compose-examples/bc-kie-server.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   business-central:
-    image: localhost/kiegroup/business-central-workbench-showcase:7.65.0.Final
+    image: localhost/kiegroup/business-central-workbench-showcase:7.66.0.Final
     ports:
       - "8080:8080"
       - "8001:8001"
@@ -9,7 +9,7 @@ services:
       KIE_SERVER_LOCATION: http://kie-server:8080/kie-server/services/rest/server
 
   kie-server:
-    image: localhost/kiegroup/kie-server-showcase:7.65.0.Final
+    image: localhost/kiegroup/kie-server-showcase:7.66.0.Final
     environment:
       KIE_SERVER_ID: sample-server
       KIE_SERVER_LOCATION: http://kie-server:8080/kie-server/services/rest/server

--- a/kie-server/base/Dockerfile
+++ b/kie-server/base/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
-ENV KIE_VERSION 7.65.0.Final
+ENV KIE_VERSION 7.66.0.Final
 ENV KIE_CLASSIFIER ee8
 ENV KIE_CONTEXT_PATH kie-server
 ENV JAVA_OPTS -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8

--- a/kie-server/base/README.md
+++ b/kie-server/base/README.md
@@ -5,7 +5,7 @@ We changed the location for our docker images from Docker to [RedHat Quay](https
 
 From the versions > 7.61.0.Final on the images will only be available on Quay.
 
-More information of KIE Server available at [KIE documentation](https://docs.jboss.org/drools/release/7.65.0.Final/drools-docs/html_single/#_ch.kie.server).
+More information of KIE Server available at [KIE documentation](https://docs.jboss.org/drools/release/7.66.0.Final/drools-docs/html_single/#_ch.kie.server).
 
 Table of contents
 ------------------
@@ -25,7 +25,7 @@ Introduction
 The image contains:    
            
 * JBoss Wildfly 23.0.2.Final
-* KIE Server 7.65.0.Final
+* KIE Server 7.66.0.Final
 
 This image provides the Drools KIE Server. It's intended to be extended so you can add your custom configurations.                 
 
@@ -35,7 +35,7 @@ Usage
 -----
 
 The JBoss KIE Execution server is intended to be used as a standalone runtime execution environment managed by a KIE Drools Workbench or a jBPM Workbench application that acts as a controller.              
-This image does not provides any default configuration, so please to use the execution server it's recommended to read the documentation at [Installing the KIE Server](https://docs.jboss.org/drools/release/7.65.0.Final/drools-docs/html_single/#_installing_the_kie_server). You can check an example of this configuration at the [KIE Server Showcase](https://registry.hub.docker.com/u/jboss/kie-server-showcase/) Docker image too.
+This image does not provides any default configuration, so please to use the execution server it's recommended to read the documentation at [Installing the KIE Server](https://docs.jboss.org/drools/release/7.66.0.Final/drools-docs/html_single/#_installing_the_kie_server). You can check an example of this configuration at the [KIE Server Showcase](https://registry.hub.docker.com/u/jboss/kie-server-showcase/) Docker image too.
 
 To run a container:
     
@@ -156,7 +156,7 @@ Notes
 -----
 
 * The context path for KIE Server application services is `kie-server`
-* Drools KIE Server version is `7.65.0.Final`
+* Drools KIE Server version is `7.66.0.Final`
 * No users or roles are configured by default               
 * No support for clustering                
 * This image is not intended to be run on cloud environments such as RedHat OpenShift or Amazon EC2, as it does not meet all the requirements.                      
@@ -167,7 +167,7 @@ Notes
 Release notes
 --------------
 
-**7.65.0.Final**
+**7.66.0.Final**
 
-* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.65.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
+* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.66.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
 

--- a/kie-server/base/build.sh
+++ b/kie-server/base/build.sh
@@ -5,7 +5,7 @@
 # ********************************************
 
 IMAGE_NAME="kiegroup/kie-server"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 # Build the container image.

--- a/kie-server/base/start.sh
+++ b/kie-server/base/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="kie-server"
 IMAGE_NAME="kiegroup/kie-server"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 function usage

--- a/kie-server/showcase/Dockerfile
+++ b/kie-server/showcase/Dockerfile
@@ -3,7 +3,7 @@
 #########################################################
 
 ####### BASE ############
-FROM kiegroup/kie-server:7.65.0.Final
+FROM kiegroup/kie-server:7.66.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"

--- a/kie-server/showcase/README.md
+++ b/kie-server/showcase/README.md
@@ -5,7 +5,7 @@ We changed the location for our docker images from Docker to [RedHat Quay](https
 
 From the versions > 7.61.0.Final on the images will only be available on Quay.
 
-More information of KIE Server available at [KIE documentation](http://docs.jboss.org/drools/release/7.65.0.Final/drools-docs/html_single/#_ch.kie.server).
+More information of KIE Server available at [KIE documentation](http://docs.jboss.org/drools/release/7.66.0.Final/drools-docs/html_single/#_ch.kie.server).
 
 Table of contents
 ------------------
@@ -25,7 +25,7 @@ Introduction
 The image contains: 
               
 * JBoss Wildfly 23.0.2.Final
-* KIE Server 7.65.0.Final
+* KIE Server 7.66.0.Final
 
 This is a **ready to run Docker image for Drools KIE Server**. Just run it and try the business-central runtime execution server!                   
 
@@ -85,7 +85,7 @@ Notes
 -----
 
 * The context path for Drools KIE Server application services is `kie-server`
-* KIE Server version is `7.65.0.Final`
+* KIE Server version is `7.66.0.Final`
 * In order to perform container linking with a jBPM / Drools Workbench image, the link alias must be `kie-wb`       
 * No support for clustering                
 * This image is not intended to be run on cloud environments such as RedHat OpenShift or Amazon EC2, as it does not meet all the requirements.                      
@@ -96,6 +96,6 @@ Notes
 Release notes
 -------------
 
-**7.65.0.Final**
+**7.66.0.Final**
 
-* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.65.0.Final/drools-docs/html_single/index.html#_ch.kie.server)
+* See release notes for [KIE-server](https://docs.jboss.org/drools/release/7.66.0.Final/drools-docs/html_single/index.html#_ch.kie.server)

--- a/kie-server/showcase/build.sh
+++ b/kie-server/showcase/build.sh
@@ -5,7 +5,7 @@
 # ************************************************
 
 IMAGE_NAME="kiegroup/kie-server-showcase"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 # Build the container image.

--- a/kie-server/showcase/start.sh
+++ b/kie-server/showcase/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="kie-server-showcase"
 IMAGE_NAME="kiegroup/kie-server-showcase"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 function usage

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://download.jboss.org/jbpm/release
-ENV KIE_VERSION 7.65.0.Final
+ENV KIE_VERSION 7.66.0.Final
 ENV KIE_CLASSIFIER wildfly23
 ENV KIE_CONTEXT_PATH business-central
 ENV KIE_SERVER_ID sample-server

--- a/server/README.md
+++ b/server/README.md
@@ -28,9 +28,9 @@ Introduction
 The image contains:
 
 * JBoss Wildfly 23.0.2.Final
-* jBPM Workbench 7.65.0.Final
-* KIE Server 7.65.0.Final
-* jBPM Case Management Showcase 7.65.0.Final
+* jBPM Workbench 7.66.0.Final
+* KIE Server 7.66.0.Final
+* jBPM Case Management Showcase 7.66.0.Final
 
 This is a **ready to run Docker image for jBPM Workbench**. Just run it and try the jBPM Workbench!
 
@@ -182,11 +182,11 @@ Try:
 Notes
 -----
 
-* jBPM Workbench version is `7.65.0.Final`
+* jBPM Workbench version is `7.66.0.Final`
 * The context path for jBPM Workbench web application is `business-central`
-* KIE Server version is `7.65.0.Final`
+* KIE Server version is `7.66.0.Final`
 * The context path for KIE Server web application is `kie-server`
-* jBPM Case Management Showcase version is `7.65.0.Final`
+* jBPM Case Management Showcase version is `7.66.0.Final`
 * The context path for jBPM Case Management Showcase web application is `jbpm-casemgmt`
 * Examples and demos are always available, also when not connected to internet
 * No support for clustering
@@ -200,6 +200,6 @@ Notes
 Release notes
 --------------
 
-**7.65.0.Final**
+**7.66.0.Final**
 
-* See release notes for [jBPM](http://docs.jboss.org/jbpm/release/7.65.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [jBPM](http://docs.jboss.org/jbpm/release/7.66.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/server/build.sh
+++ b/server/build.sh
@@ -5,7 +5,7 @@
 # ***************************************************
 
 IMAGE_NAME="kiegroup/jbpm-server-full"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 # Build the container image.

--- a/server/etc/start_jbpm-wb.sh
+++ b/server/etc/start_jbpm-wb.sh
@@ -4,5 +4,5 @@
 echo "Update database connection setup"
 ./update_db_config.sh
 echo "Running jBPM Server Full on JBoss Wildfly..."
-exec ./standalone.sh -c standalone-full-ha.xml -b $JBOSS_BIND_ADDRESS $EXTRA_OPTS -Dorg.kie.server.location=$KIE_SERVER_LOCATION -Dorg.kie.server.id=$KIE_SERVER_ID -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true
+exec ./standalone.sh -b $JBOSS_BIND_ADDRESS $EXTRA_OPTS -Dorg.kie.server.location=$KIE_SERVER_LOCATION -Dorg.kie.server.id=$KIE_SERVER_ID -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true
 exit $?

--- a/server/start.sh
+++ b/server/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="jbpm-server-full"
 IMAGE_NAME="kiegroup/jbpm-server-full"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 function usage

--- a/showcase/Dockerfile
+++ b/showcase/Dockerfile
@@ -3,7 +3,7 @@
 ############################################################################
 
 ####### BASE ############
-FROM kiegroup/business-central-workbench:7.65.0.Final
+FROM kiegroup/business-central-workbench:7.66.0.Final
 
 ####### MAINTAINER ############
 MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -25,7 +25,7 @@ Introduction
 The image contains:
 
 * JBoss Wildfly 23.0.2.Final
-* KIE Business-Central Workbench 7.65.0.Final
+* KIE Business-Central Workbench 7.66.0.Final
 
 This image inherits from `quay.io/kiegroup/business-central-workbench:latest` and provides some additional configurations:
 
@@ -186,7 +186,7 @@ Notes
 -----
 
 * The context path for KIE Business-Central Workbench web application is `business-central`
-* KIE Business-Central Workbench version is `7.65.0.Final`
+* KIE Business-Central Workbench version is `7.66.0.Final`
 * Examples and demos are always available, also when not connected to internet
 * No support for clustering
 * Use of embedded H2 database server by default
@@ -199,6 +199,6 @@ Notes
 Release notes
 --------------
 
-**7.65.0.Final**
+**7.66.0.Final**
 
-* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.65.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)
+* See release notes for [Business-Central](http://docs.jboss.org/jbpm/release/7.66.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes)

--- a/showcase/build.sh
+++ b/showcase/build.sh
@@ -5,7 +5,7 @@
 # *********************************************************************
 
 IMAGE_NAME="kiegroup/business-central-workbench-showcase"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 # Build the container image.

--- a/showcase/start.sh
+++ b/showcase/start.sh
@@ -13,7 +13,7 @@
 
 CONTAINER_NAME="business-central-workbench-showcase"
 IMAGE_NAME="kiegroup/business-central-workbench-showcase"
-IMAGE_TAG="7.65.0.Final"
+IMAGE_TAG="7.66.0.Final"
 
 
 function usage


### PR DESCRIPTION
the commit https://github.com/jboss-dockerfiles/business-central/commit/5e40644e0893c76f7e57cc8abf493e6667efad5a had to be reverted since you couldn't access any more with predefined user.
If a user wants to start with the **standalone-full-ha.xml**, I suggest he should do these kind of  changes